### PR TITLE
Test: Trigger auto-fix workflow with syntax error

### DIFF
--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -4,7 +4,7 @@ export type RetryOptions = {
   maxDelayMs?: number;
   backoffFactor?: number;
 };
-
+console.log("asdf);
 export async function retryWithBackoff<T>(
   operation: () => Promise<T>,
   options: RetryOptions = {},


### PR DESCRIPTION
This PR reintroduces the syntax error from PR #93 to test the auto-fix CI workflow.

The error is in src/utils/retry.ts line 7: `console.log("asdf);` (missing closing quote)

This should trigger:
1. CI failure due to syntax error
2. Auto-fix workflow via workflow_run event  
3. Claude should analyze and fix the error

Testing with updated v1-dev that includes debug logging.