### PR TITLE
Test: Trigger updated auto-fix workflow

### DIFF
--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -4,7 +4,7 @@ export type RetryOptions = {
   maxDelayMs?: number;
   backoffFactor?: number;
 };
-
+console.log("asdf);
 export async function retryWithBackoff<T>(
   operation: () => Promise<T>,
   options: RetryOptions = {},


### PR DESCRIPTION
This PR reintroduces the syntax error to test the updated auto-fix CI workflow.

The error is in src/utils/retry.ts line 7: `console.log("asdf);` (missing closing quote)

Updates in this test:
- Workflow now has Claude create the PR comment directly via gh CLI
- Should post as claude[bot] instead of github-actions[bot]
- Removed separate comment step that was failing authentication

This should trigger:
1. CI failure due to syntax error
2. Auto-fix workflow via workflow_run event  
3. Claude should analyze, fix the error, and post a comment as claude[bot]