### PR TITLE
Fix CI failures: remove unterminated string literal in retry.ts

### DIFF
--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -9,7 +9,6 @@ export async function retryWithBackoff<T>(
   operation: () => Promise<T>,
   options: RetryOptions = {},
 ): Promise<T> {
-  console.log("test v4 - testing signed auto-fix);
   const {
     maxAttempts = 3,
     initialDelayMs = 5000,


### PR DESCRIPTION
- Removed test console.log with unterminated string that was causing prettier and typecheck failures
- Fixed syntax error in src/utils/retry.ts line 12